### PR TITLE
Remove dependency on github.com/pajbot/utils library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Dev: Remove dependency on github.com/pajbot/utils library. (#6)


### PR DESCRIPTION
Instead of generating a random string for our nonces, we just use an
atomic counter

Fixes #2
