### PR TITLE
Unlock mutexes only on defer

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -90,8 +90,8 @@ func (c *connection) startReader() {
 
 func (c *connection) onPong() {
 	c.pongMutex.Lock()
+	defer c.pongMutex.Unlock()
 	c.lastPong = time.Now()
-	c.pongMutex.Unlock()
 }
 
 func (c *connection) lastPongWithinLimits(pingTime time.Time) bool {
@@ -143,8 +143,8 @@ func (c *connection) startPing() {
 
 func (c *connection) setConnected(newConnectedState bool) {
 	c.connectedMutex.Lock()
+	defer c.connectedMutex.Unlock()
 	c.connected = newConnectedState
-	c.connectedMutex.Unlock()
 }
 
 func (c *connection) stopWriter() {


### PR DESCRIPTION
Small finding I've noticed while going through code of this library. While it may bring no change, it feels more correct to do this on defer.
