### PR TITLE
Fix WhisperEvent struct

### DIFF
--- a/whispers.go
+++ b/whispers.go
@@ -13,15 +13,13 @@ const whisperEventTopicPrefix = "whispers."
 
 // WhisperEvent describes an incoming whisper coming from Twitch's PubSub servers
 type WhisperEvent struct {
-	Type string `json:"type"`
-	Data struct {
-		ID int `json:"id"`
-	} `json:"data"`
-	ThreadID string `json:"thread_id"`
-	Body     string `json:"body"`
-	SentTs   int    `json:"sent_ts"`
-	FromID   int    `json:"from_id"`
-	Tags     struct {
+	MessageID string `json:"message_id"`
+	ID        int    `json:"id"`
+	ThreadID  string `json:"thread_id"`
+	Body      string `json:"body"`
+	SentTs    int    `json:"sent_ts"`
+	FromID    int    `json:"from_id"`
+	Tags      struct {
 		Login       string        `json:"login"`
 		DisplayName string        `json:"display_name"`
 		Color       string        `json:"color"`
@@ -32,32 +30,37 @@ type WhisperEvent struct {
 		} `json:"badges"`
 	} `json:"tags"`
 	Recipient struct {
-		ID          int           `json:"id"`
-		Username    string        `json:"username"`
-		DisplayName string        `json:"display_name"`
-		Color       string        `json:"color"`
-		Badges      []interface{} `json:"badges"`
+		ID          int    `json:"id"`
+		Username    string `json:"username"`
+		DisplayName string `json:"display_name"`
+		Color       string `json:"color"`
 	} `json:"recipient"`
 	Nonce string `json:"nonce"`
 }
 
+type outerWhisperEvent struct {
+	Type       string       `json:"type"`
+	Data       string       `json:"data"`
+	DataObject WhisperEvent `json:"data_object"`
+}
+
 func parseWhisperEvent(bytes []byte) (*WhisperEvent, error) {
-	data := &WhisperEvent{}
+	data := &outerWhisperEvent{}
 	err := json.Unmarshal(bytes, data)
 	if err != nil {
 		return nil, err
 	}
 
-	return data, nil
+	return &data.DataObject, nil
 }
 
 func parseUserIDFromWhisperTopic(topic string) (string, error) {
 	parts := strings.Split(topic, ".")
-	if len(parts) != 3 {
+	if len(parts) != 2 {
 		return "", errors.New("unable to parse channel ID from whisper topic")
 	}
 
-	return parts[2], nil
+	return parts[1], nil
 }
 
 // WhisperEventTopic returns a properly formatted whisper event topic string with the given userID ID argument


### PR DESCRIPTION
The Whisper Event Message documentation (https://dev.twitch.tv/docs/pubsub/#topics) seems to be outdated and doesn't reflect what PubSub actually sends. This commit uses a struct that was created based off production data instead.